### PR TITLE
Add shutdown handler

### DIFF
--- a/modules/admin.py
+++ b/modules/admin.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import logging
 from aiogram import Router
 from aiogram.filters import Command
 from aiogram.types import Message
@@ -9,11 +10,13 @@ from dotenv import load_dotenv
 from modules.db import db
 
 router = Router()
+log = logging.getLogger(__name__)
 
 
 async def startup() -> None:
     load_dotenv()
     await db.execute("CREATE TABLE IF NOT EXISTS admins(user_id BIGINT PRIMARY KEY)")
+    log.info("Admins table ensured")
 
 
 def _owner_only(func):
@@ -22,6 +25,7 @@ def _owner_only(func):
         if message.from_user and message.from_user.id == owner_id:
             return await func(message, *args, **kwargs)
         await message.answer("🚫 Access denied.")
+
     return wrapper
 
 
@@ -32,10 +36,15 @@ async def add_admin(message: Message) -> None:
     if len(parts) != 2:
         await message.answer("Usage: /add_admin <user_id>")
         return
-    uid = int(parts[1])
+    try:
+        uid = int(parts[1])
+    except ValueError:
+        await message.answer("Invalid user ID")
+        return
     await db.execute(
         "INSERT INTO admins(user_id) VALUES($1) ON CONFLICT DO NOTHING", uid
     )
+    log.info("Added admin %s", uid)
     await message.answer(f"Added admin {uid}")
 
 
@@ -46,8 +55,13 @@ async def rm_admin(message: Message) -> None:
     if len(parts) != 2:
         await message.answer("Usage: /rm_admin <user_id>")
         return
-    uid = int(parts[1])
+    try:
+        uid = int(parts[1])
+    except ValueError:
+        await message.answer("Invalid user ID")
+        return
     await db.execute("DELETE FROM admins WHERE user_id=$1", uid)
+    log.info("Removed admin %s", uid)
     await message.answer(f"Removed admin {uid}")
 
 
@@ -57,4 +71,5 @@ async def list_admin(message: Message) -> None:
     rows = await db.fetch("SELECT user_id FROM admins")
     admins = [str(r["user_id"]) for r in rows]
     text = ", ".join(admins) if admins else "No admins."
+    log.info("Listed admins: %s", text)
     await message.answer(text)

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,0 +1,58 @@
+import os
+import sys
+import pathlib
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from modules import admin
+
+os.environ["OWNER_ID"] = "1"
+
+
+class DummyUser:
+    def __init__(self, user_id):
+        self.id = user_id
+
+
+class DummyMessage:
+    def __init__(self, text):
+        self.text = text
+        self.from_user = DummyUser(1)
+        self.answers = []
+
+    async def answer(self, text):
+        self.answers.append(text)
+
+
+def make_msg(text: str):
+    return DummyMessage(text)
+
+
+@pytest.mark.asyncio
+async def test_add_admin_invalid(monkeypatch):
+    called = False
+
+    async def dummy_execute(*args, **kwargs):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(admin.db, "execute", dummy_execute)
+    msg = make_msg("/add_admin abc")
+    await admin.add_admin(msg)
+    assert msg.answers == ["Invalid user ID"]
+    assert not called
+
+
+@pytest.mark.asyncio
+async def test_rm_admin_invalid(monkeypatch):
+    called = False
+
+    async def dummy_execute(*args, **kwargs):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(admin.db, "execute", dummy_execute)
+    msg = make_msg("/rm_admin abc")
+    await admin.rm_admin(msg)
+    assert msg.answers == ["Invalid user ID"]
+    assert not called


### PR DESCRIPTION
## Summary
- setup logging configuration in `bot.py`
- add shutdown routine for DB and HTTP session
- register the shutdown hook with the dispatcher
- validate user input for admin commands
- add tests for invalid admin IDs

## Testing
- `black modules/admin.py tests/test_admin.py bot.py --line-length 88`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a5705a5c0832ea6a6a51f3a2bc63b