### PR TITLE
Add guests table initialization and tests

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -9,7 +9,7 @@ from dotenv import load_dotenv
 from aiogram import Bot, Dispatcher, types
 from aiogram.filters import Command
 
-from modules.db import db
+from modules.db import db, init_guests_table
 from modules.admin import startup as admin_startup
 
 load_dotenv()
@@ -60,6 +60,7 @@ async def on_startup():
     """Connect DB and load routers from modules package."""
     await db.connect()
     await admin_startup()  # create tables
+    await init_guests_table()
 
     for _, name, _ in pkgutil.iter_modules(["modules"]):
         if name.startswith("_"):

--- a/modules/db.py
+++ b/modules/db.py
@@ -47,3 +47,21 @@ class Database:
 
 
 db = Database()
+
+
+async def init_guests_table() -> None:
+    await db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS guests(
+            id SERIAL PRIMARY KEY,
+            uuid TEXT UNIQUE NOT NULL,
+            tg_id BIGINT NULL,
+            name TEXT,
+            phone TEXT,
+            dob DATE,
+            source TEXT,
+            created_at TIMESTAMP DEFAULT now()
+        )
+        """
+    )
+    log.info("guests table ensured")

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,31 @@
+import os
+import sys
+import pathlib
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from modules.db import db, init_guests_table
+
+DSN = 'postgresql://postgres:postgres@localhost/testdb'
+
+@pytest.mark.asyncio
+async def test_init_guests_table():
+    os.environ['POSTGRES_DSN'] = DSN
+    await db.connect()
+    await db.execute('DROP TABLE IF EXISTS guests')
+    await init_guests_table()
+    exists = await db.fetchval("SELECT to_regclass('public.guests')")
+    cols = await db.fetch(
+        """
+        SELECT column_name FROM information_schema.columns
+        WHERE table_name='guests'
+        ORDER BY ordinal_position
+        """
+    )
+    await db.close()
+    assert exists == 'guests'
+    names = [r['column_name'] for r in cols]
+    assert names == [
+        'id', 'uuid', 'tg_id', 'name', 'phone', 'dob', 'source', 'created_at'
+    ]
+


### PR DESCRIPTION
## Summary
- ensure guests table exists via `init_guests_table`
- call table init during startup
- verify table creation in new pytest

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866551ea430832ea05dd79dbf3c0b90