### PR TITLE
Add guests table initialization and tests

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -9,7 +9,7 @@ from dotenv import load_dotenv
 from aiogram import Bot, Dispatcher, types
 from aiogram.filters import Command
 
-from modules.db import db
+from modules.db import db, init_guests_table
 from modules.admin import startup as admin_startup
 
 load_dotenv()
@@ -41,8 +41,10 @@ START_TIME = datetime.now()
 
 @dp.message(Command("start"))
 async def start_cmd(message: types.Message) -> None:
+    parts = message.text.split() if message.text else []
     if message.from_user.id != OWNER_ID:
-        await message.answer("🚫 Access denied.")
+        if len(parts) == 1:
+            await message.answer("🚫 Access denied.")
         return
     delta = datetime.now() - START_TIME
     days = delta.days
@@ -60,6 +62,7 @@ async def on_startup():
     """Connect DB and load routers from modules package."""
     await db.connect()
     await admin_startup()  # create tables
+    await init_guests_table()
 
     for _, name, _ in pkgutil.iter_modules(["modules"]):
         if name.startswith("_"):

--- a/modules/db.py
+++ b/modules/db.py
@@ -47,3 +47,21 @@ class Database:
 
 
 db = Database()
+
+
+async def init_guests_table() -> None:
+    await db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS guests(
+            id SERIAL PRIMARY KEY,
+            uuid TEXT UNIQUE NOT NULL,
+            tg_id BIGINT NULL,
+            name TEXT,
+            phone TEXT,
+            dob DATE,
+            source TEXT,
+            created_at TIMESTAMP DEFAULT now()
+        )
+        """
+    )
+    log.info("guests table ensured")

--- a/modules/reqqr.py
+++ b/modules/reqqr.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+import os
+import logging
+from aiogram import Router, Bot
+from aiogram.filters import Command
+from aiogram.types import Message
+
+from modules.db import db
+
+router = Router()
+log = logging.getLogger(__name__)
+
+
+@router.message(Command("start"))
+async def start_uuid(message: Message, bot: Bot) -> None:
+    parts = message.text.split() if message.text else []
+    if len(parts) != 2:
+        return
+    uuid = parts[1]
+    row = await db.fetchrow("SELECT tg_id FROM guests WHERE uuid=$1", uuid)
+    if not row:
+        await message.answer("❌ Invalid QR code.")
+        return
+    if row["tg_id"]:
+        await message.answer("You are already registered.")
+        return
+    await db.execute(
+        "UPDATE guests SET tg_id=$1, name=$2, source='qr' WHERE uuid=$3",
+        message.from_user.id,
+        message.from_user.username,
+        uuid,
+    )
+    channel_id = os.getenv("CHANNEL_ID")
+    if channel_id:
+        try:
+            link = await bot.create_chat_invite_link(int(channel_id), member_limit=1)
+            await bot.send_message(message.from_user.id, link.invite_link)
+        except Exception as e:
+            log.exception("invite failed: %s", e)
+            await message.answer("Registered, but invite failed.")
+            return
+    await message.answer("✅ Registration complete.")

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,31 @@
+import os
+import sys
+import pathlib
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from modules.db import db, init_guests_table
+
+DSN = 'postgresql://postgres:postgres@localhost/testdb'
+
+@pytest.mark.asyncio
+async def test_init_guests_table():
+    os.environ['POSTGRES_DSN'] = DSN
+    await db.connect()
+    await db.execute('DROP TABLE IF EXISTS guests')
+    await init_guests_table()
+    exists = await db.fetchval("SELECT to_regclass('public.guests')")
+    cols = await db.fetch(
+        """
+        SELECT column_name FROM information_schema.columns
+        WHERE table_name='guests'
+        ORDER BY ordinal_position
+        """
+    )
+    await db.close()
+    assert exists == 'guests'
+    names = [r['column_name'] for r in cols]
+    assert names == [
+        'id', 'uuid', 'tg_id', 'name', 'phone', 'dob', 'source', 'created_at'
+    ]
+

--- a/tests/test_reqqr.py
+++ b/tests/test_reqqr.py
@@ -1,0 +1,84 @@
+import os
+import sys
+import pathlib
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from modules import reqqr
+
+
+class DummyUser:
+    def __init__(self, uid, username="name"):
+        self.id = uid
+        self.username = username
+
+
+class DummyBot:
+    def __init__(self):
+        self.created = []
+        self.sent = []
+
+    async def create_chat_invite_link(self, chat_id, member_limit=1):
+        self.created.append((chat_id, member_limit))
+        return type("Link", (), {"invite_link": "link"})()
+
+    async def send_message(self, chat_id, text):
+        self.sent.append((chat_id, text))
+
+
+class DummyMessage:
+    def __init__(self, text):
+        self.text = text
+        self.answers = []
+        self.from_user = DummyUser(42, "user")
+        self.bot = DummyBot()
+
+    async def answer(self, text):
+        self.answers.append(text)
+
+
+def make_msg(text="/start good"):
+    return DummyMessage(text)
+
+
+@pytest.mark.asyncio
+async def test_start_uuid_new(monkeypatch):
+    called = {}
+
+    async def dummy_fetchrow(q, uuid):
+        assert uuid == "good"
+        return {"tg_id": None}
+
+    async def dummy_execute(q, *args):
+        called["exec"] = args
+
+    monkeypatch.setattr(reqqr.db, "fetchrow", dummy_fetchrow)
+    monkeypatch.setattr(reqqr.db, "execute", dummy_execute)
+    os.environ["CHANNEL_ID"] = "123"
+    msg = make_msg()
+    await reqqr.start_uuid(msg, bot=msg.bot)
+    assert called["exec"] == (42, "user", "good")
+    assert msg.bot.created and msg.bot.sent
+    assert msg.answers == ["✅ Registration complete."]
+
+
+@pytest.mark.asyncio
+async def test_start_uuid_duplicate(monkeypatch):
+    async def dummy_fetchrow(q, uuid):
+        return {"tg_id": 42}
+
+    monkeypatch.setattr(reqqr.db, "fetchrow", dummy_fetchrow)
+    msg = make_msg()
+    await reqqr.start_uuid(msg, bot=msg.bot)
+    assert msg.answers == ["You are already registered."]
+
+
+@pytest.mark.asyncio
+async def test_start_uuid_invalid(monkeypatch):
+    async def dummy_fetchrow(q, uuid):
+        return None
+
+    monkeypatch.setattr(reqqr.db, "fetchrow", dummy_fetchrow)
+    msg = make_msg("/start bad")
+    await reqqr.start_uuid(msg, bot=msg.bot)
+    assert msg.answers == ["❌ Invalid QR code."]


### PR DESCRIPTION
## Summary
- ensure guests table exists via `init_guests_table`
- call table init during startup
- verify table creation in new pytest
- add qr registration with channel invite

## Testing
- `ruff check .`
- `pytest -q` *(fails: could not connect to test database)*

------
https://chatgpt.com/codex/tasks/task_e_6866551ea430832ea05dd79dbf3c0b90