### PR TITLE
Implement automatic offer consent and visit tracking

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -9,7 +9,7 @@ from dotenv import load_dotenv
 from aiogram import Bot, Dispatcher, types
 from aiogram.filters import Command
 
-from modules.db import db, init_guests_table
+from modules.db import db, init_guests_table, init_visits_table
 from modules.admin import startup as admin_startup
 
 load_dotenv()
@@ -63,6 +63,7 @@ async def on_startup():
     await db.connect()
     await admin_startup()  # create tables
     await init_guests_table()
+    await init_visits_table()
 
     for _, name, _ in pkgutil.iter_modules(["modules"]):
         if name.startswith("_"):

--- a/modules/db.py
+++ b/modules/db.py
@@ -60,8 +60,22 @@ async def init_guests_table() -> None:
             phone TEXT,
             dob DATE,
             source TEXT,
-            created_at TIMESTAMP DEFAULT now()
+            created_at TIMESTAMP DEFAULT now(),
+            agreed_at TIMESTAMP
         )
         """
     )
     log.info("guests table ensured")
+
+
+async def init_visits_table() -> None:
+    await db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS visits(
+            id SERIAL PRIMARY KEY,
+            guest_id INTEGER REFERENCES guests(id),
+            ts TIMESTAMP DEFAULT now()
+        )
+        """
+    )
+    log.info("visits table ensured")

--- a/modules/report.py
+++ b/modules/report.py
@@ -1,0 +1,40 @@
+import logging
+from aiogram import Router
+from aiogram.filters import Command
+from aiogram.types import Message
+
+from modules.db import db
+from modules.admin import _admin_only
+
+router = Router()
+log = logging.getLogger(__name__)
+
+
+@router.message(Command("report"))
+@_admin_only
+async def report_cmd(message: Message) -> None:
+    total_guests = await db.fetchval("SELECT COUNT(*) FROM guests")
+    unique_week = await db.fetchval(
+        "SELECT COUNT(DISTINCT guest_id) FROM visits WHERE ts >= now() - interval '7 days'"
+    )
+    unique_month = await db.fetchval(
+        "SELECT COUNT(DISTINCT guest_id) FROM visits WHERE ts >= date_trunc('month', now())"
+    )
+    total_visits = await db.fetchval("SELECT COUNT(*) FROM visits")
+    repeat_visitors = await db.fetchval(
+        "SELECT COUNT(*) FROM (SELECT guest_id FROM visits GROUP BY guest_id HAVING COUNT(*) > 1) t"
+    )
+    rows = await db.fetch(
+        "SELECT g.name, COUNT(*) AS c FROM visits v JOIN guests g ON g.id=v.guest_id "
+        "GROUP BY g.name ORDER BY c DESC LIMIT 3"
+    )
+    top = ", ".join(f"{r['name'] or '-'}-{r['c']}" for r in rows)
+    text = (
+        f"Всего гостей: {total_guests}\n"
+        f"Уникальных за неделю: {unique_week}\n"
+        f"Уникальных за месяц: {unique_month}\n"
+        f"Всего визитов: {total_visits}\n"
+        f"Повторных гостей: {repeat_visitors}\n"
+        f"Топ гости: {top}"
+    )
+    await message.answer(text)

--- a/modules/reqqr.py
+++ b/modules/reqqr.py
@@ -34,29 +34,32 @@ async def start_uuid(message: Message, bot: Bot) -> None:
     if len(parts) != 2:
         return
     uuid = parts[1]
-    row = await db.fetchrow("SELECT tg_id FROM guests WHERE uuid=$1", uuid)
+    row = await db.fetchrow("SELECT id, tg_id FROM guests WHERE uuid=$1", uuid)
     if not row:
         await message.answer("❌ Invalid QR code.")
         return
-    if row["tg_id"]:
-        await message.answer("You are already registered.")
-        return
-    await db.execute(
-        "UPDATE guests SET tg_id=$1, name=$2, source='qr' WHERE uuid=$3",
-        message.from_user.id,
-        message.from_user.username,
-        uuid,
-    )
-    channel_id = os.getenv("CHANNEL_ID")
-    if channel_id:
-        try:
-            link = await bot.create_chat_invite_link(int(channel_id), member_limit=1)
-            await bot.send_message(message.from_user.id, link.invite_link)
-        except Exception as e:
-            log.exception("invite failed: %s", e)
-            await message.answer("Registered, but invite failed.")
-            return
-    await message.answer("✅ Registration complete.")
+    guest_id = row["id"]
+    if row["tg_id"] is None:
+        await db.execute(
+            "UPDATE guests SET tg_id=$1, name=$2, source='qr', agreed_at=now() WHERE uuid=$3",
+            message.from_user.id,
+            message.from_user.username,
+            uuid,
+        )
+        await message.answer("✅ Registration complete. Согласие получено.")
+    await db.execute("INSERT INTO visits(guest_id) VALUES($1)", guest_id)
+    count = await db.fetchval("SELECT COUNT(*) FROM visits WHERE guest_id=$1", guest_id)
+    if count == 1:
+        channel_id = os.getenv("CHANNEL_ID")
+        if channel_id:
+            try:
+                link = await bot.create_chat_invite_link(int(channel_id), member_limit=1)
+                await bot.send_message(message.from_user.id, link.invite_link)
+            except Exception as e:
+                log.exception("invite failed: %s", e)
+                await message.answer("Registered, but invite failed.")
+    else:
+        await message.answer(f"Это уже {count}-е посещение")
 
 
 @router.message(Command("reg"))

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -26,6 +26,6 @@ async def test_init_guests_table():
     assert exists == 'guests'
     names = [r['column_name'] for r in cols]
     assert names == [
-        'id', 'uuid', 'tg_id', 'name', 'phone', 'dob', 'source', 'created_at'
+        'id', 'uuid', 'tg_id', 'name', 'phone', 'dob', 'source', 'created_at', 'agreed_at'
     ]
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,55 @@
+import os
+import sys
+import pathlib
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from modules import report
+
+os.environ["OWNER_ID"] = "1"
+
+
+class DummyUser:
+    def __init__(self, uid=1):
+        self.id = uid
+
+
+class DummyMessage:
+    def __init__(self, text="/report"):
+        self.text = text
+        self.from_user = DummyUser()
+        self.answers = []
+
+    async def answer(self, text):
+        self.answers.append(text)
+
+
+def make_msg(text="/report"):
+    return DummyMessage(text)
+
+
+@pytest.mark.asyncio
+async def test_report(monkeypatch):
+    async def dummy_fetchval(query):
+        if "FROM guests" in query:
+            return 10
+        if "7 days" in query:
+            return 5
+        if "date_trunc" in query:
+            return 7
+        if "COUNT(*) FROM visits" in query:
+            return 20
+        return 3
+
+    async def dummy_fetch(query):
+        return [
+            {"name": "A", "c": 5},
+            {"name": "B", "c": 4},
+            {"name": "C", "c": 3},
+        ]
+
+    monkeypatch.setattr(report.db, "fetchval", dummy_fetchval)
+    monkeypatch.setattr(report.db, "fetch", dummy_fetch)
+    msg = make_msg()
+    await report.report_cmd(msg)
+    assert msg.answers and "Всего гостей: 10" in msg.answers[0]


### PR DESCRIPTION
## Summary
- record guest consent with new `agreed_at` column
- log guest visits in a new `visits` table
- update `/start` logic to set consent, track visits and reply on repeat
- add `/report` command for visit statistics
- add tests for `/report` logic

## Testing
- `pytest -q` *(fails: could not connect to PostgreSQL)*

------
https://chatgpt.com/codex/tasks/task_e_686b7c025264832eadbf5a701a5979f5