### PR TITLE
Implement automatic offer consent and visit tracking

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -9,7 +9,7 @@ from dotenv import load_dotenv
 from aiogram import Bot, Dispatcher, types
 from aiogram.filters import Command
 
-from modules.db import db, init_guests_table
+from modules.db import db, init_guests_table, init_visits_table
 from modules.admin import startup as admin_startup
 
 load_dotenv()
@@ -63,6 +63,7 @@ async def on_startup():
     await db.connect()
     await admin_startup()  # create tables
     await init_guests_table()
+    await init_visits_table()
 
     for _, name, _ in pkgutil.iter_modules(["modules"]):
         if name.startswith("_"):

--- a/modules/db.py
+++ b/modules/db.py
@@ -60,8 +60,22 @@ async def init_guests_table() -> None:
             phone TEXT,
             dob DATE,
             source TEXT,
-            created_at TIMESTAMP DEFAULT now()
+            created_at TIMESTAMP DEFAULT now(),
+            agreed_at TIMESTAMP
         )
         """
     )
     log.info("guests table ensured")
+
+
+async def init_visits_table() -> None:
+    await db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS visits(
+            id SERIAL PRIMARY KEY,
+            guest_id INTEGER REFERENCES guests(id),
+            ts TIMESTAMP DEFAULT now()
+        )
+        """
+    )
+    log.info("visits table ensured")

--- a/modules/report.py
+++ b/modules/report.py
@@ -1,0 +1,40 @@
+import logging
+from aiogram import Router
+from aiogram.filters import Command
+from aiogram.types import Message
+
+from modules.db import db
+from modules.admin import _admin_only
+
+router = Router()
+log = logging.getLogger(__name__)
+
+
+@router.message(Command("report"))
+@_admin_only
+async def report_cmd(message: Message) -> None:
+    total_guests = await db.fetchval("SELECT COUNT(*) FROM guests")
+    unique_week = await db.fetchval(
+        "SELECT COUNT(DISTINCT guest_id) FROM visits WHERE ts >= now() - interval '7 days'"
+    )
+    unique_month = await db.fetchval(
+        "SELECT COUNT(DISTINCT guest_id) FROM visits WHERE ts >= date_trunc('month', now())"
+    )
+    total_visits = await db.fetchval("SELECT COUNT(*) FROM visits")
+    repeat_visitors = await db.fetchval(
+        "SELECT COUNT(*) FROM (SELECT guest_id FROM visits GROUP BY guest_id HAVING COUNT(*) > 1) t"
+    )
+    rows = await db.fetch(
+        "SELECT g.name, COUNT(*) AS c FROM visits v JOIN guests g ON g.id=v.guest_id "
+        "GROUP BY g.name ORDER BY c DESC LIMIT 3"
+    )
+    top = ", ".join(f"{r['name'] or '-'}-{r['c']}" for r in rows)
+    text = (
+        f"Всего гостей: {total_guests}\n"
+        f"Уникальных за неделю: {unique_week}\n"
+        f"Уникальных за месяц: {unique_month}\n"
+        f"Всего визитов: {total_visits}\n"
+        f"Повторных гостей: {repeat_visitors}\n"
+        f"Топ гости: {top}"
+    )
+    await message.answer(text)

--- a/modules/reqqr.py
+++ b/modules/reqqr.py
@@ -34,29 +34,32 @@ async def start_uuid(message: Message, bot: Bot) -> None:
     if len(parts) != 2:
         return
     uuid = parts[1]
-    row = await db.fetchrow("SELECT tg_id FROM guests WHERE uuid=$1", uuid)
+    row = await db.fetchrow("SELECT id, tg_id FROM guests WHERE uuid=$1", uuid)
     if not row:
         await message.answer("❌ Invalid QR code.")
         return
-    if row["tg_id"]:
-        await message.answer("You are already registered.")
-        return
-    await db.execute(
-        "UPDATE guests SET tg_id=$1, name=$2, source='qr' WHERE uuid=$3",
-        message.from_user.id,
-        message.from_user.username,
-        uuid,
-    )
-    channel_id = os.getenv("CHANNEL_ID")
-    if channel_id:
-        try:
-            link = await bot.create_chat_invite_link(int(channel_id), member_limit=1)
-            await bot.send_message(message.from_user.id, link.invite_link)
-        except Exception as e:
-            log.exception("invite failed: %s", e)
-            await message.answer("Registered, but invite failed.")
-            return
-    await message.answer("✅ Registration complete.")
+    guest_id = row["id"]
+    if row["tg_id"] is None:
+        await db.execute(
+            "UPDATE guests SET tg_id=$1, name=$2, source='qr', agreed_at=now() WHERE uuid=$3",
+            message.from_user.id,
+            message.from_user.username,
+            uuid,
+        )
+        await message.answer("✅ Registration complete. Согласие получено.")
+    await db.execute("INSERT INTO visits(guest_id) VALUES($1)", guest_id)
+    count = await db.fetchval("SELECT COUNT(*) FROM visits WHERE guest_id=$1", guest_id)
+    if count == 1:
+        channel_id = os.getenv("CHANNEL_ID")
+        if channel_id:
+            try:
+                link = await bot.create_chat_invite_link(int(channel_id), member_limit=1)
+                await bot.send_message(message.from_user.id, link.invite_link)
+            except Exception as e:
+                log.exception("invite failed: %s", e)
+                await message.answer("Registered, but invite failed.")
+    else:
+        await message.answer(f"Это уже {count}-е посещение")
 
 
 @router.message(Command("reg"))
@@ -87,6 +90,8 @@ async def reg_guest(message: Message) -> None:
         phone,
         dob_str,
     )
+    guest_id = await db.fetchval("SELECT id FROM guests WHERE uuid=$1", uuid)
+    await db.execute("INSERT INTO visits(guest_id) VALUES($1)", guest_id)
     await message.answer("✅ Guest registered.")
 
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -26,6 +26,6 @@ async def test_init_guests_table():
     assert exists == 'guests'
     names = [r['column_name'] for r in cols]
     assert names == [
-        'id', 'uuid', 'tg_id', 'name', 'phone', 'dob', 'source', 'created_at'
+        'id', 'uuid', 'tg_id', 'name', 'phone', 'dob', 'source', 'created_at', 'agreed_at'
     ]
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,55 @@
+import os
+import sys
+import pathlib
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from modules import report
+
+os.environ["OWNER_ID"] = "1"
+
+
+class DummyUser:
+    def __init__(self, uid=1):
+        self.id = uid
+
+
+class DummyMessage:
+    def __init__(self, text="/report"):
+        self.text = text
+        self.from_user = DummyUser()
+        self.answers = []
+
+    async def answer(self, text):
+        self.answers.append(text)
+
+
+def make_msg(text="/report"):
+    return DummyMessage(text)
+
+
+@pytest.mark.asyncio
+async def test_report(monkeypatch):
+    async def dummy_fetchval(query):
+        if "FROM guests" in query:
+            return 10
+        if "7 days" in query:
+            return 5
+        if "date_trunc" in query:
+            return 7
+        if "COUNT(*) FROM visits" in query:
+            return 20
+        return 3
+
+    async def dummy_fetch(query):
+        return [
+            {"name": "A", "c": 5},
+            {"name": "B", "c": 4},
+            {"name": "C", "c": 3},
+        ]
+
+    monkeypatch.setattr(report.db, "fetchval", dummy_fetchval)
+    monkeypatch.setattr(report.db, "fetch", dummy_fetch)
+    msg = make_msg()
+    await report.report_cmd(msg)
+    assert msg.answers and "Всего гостей: 10" in msg.answers[0]

--- a/tests/test_reqqr.py
+++ b/tests/test_reqqr.py
@@ -50,34 +50,53 @@ def make_msg(text="/start good"):
 
 @pytest.mark.asyncio
 async def test_start_uuid_new(monkeypatch):
-    called = {}
+    calls = {"update": None, "visits": 0}
 
     async def dummy_fetchrow(q, uuid):
         assert uuid == "good"
-        return {"tg_id": None}
+        return {"id": 1, "tg_id": None}
 
     async def dummy_execute(q, *args):
-        called["exec"] = args
+        if "UPDATE guests" in q:
+            calls["update"] = args
+        elif "INSERT INTO visits" in q:
+            calls["visits"] += 1
+
+    async def dummy_fetchval(q, *args):
+        return calls["visits"]
 
     monkeypatch.setattr(reqqr.db, "fetchrow", dummy_fetchrow)
     monkeypatch.setattr(reqqr.db, "execute", dummy_execute)
+    monkeypatch.setattr(reqqr.db, "fetchval", dummy_fetchval)
     os.environ["CHANNEL_ID"] = "123"
     msg = make_msg()
     await reqqr.start_uuid(msg, bot=msg.bot)
-    assert called["exec"] == (42, "user", "good")
+    assert calls["update"] == (42, "user", "good")
     assert msg.bot.created and msg.bot.sent
-    assert msg.answers == ["✅ Registration complete."]
+    assert msg.answers == ["✅ Registration complete. Согласие получено."]
 
 
 @pytest.mark.asyncio
-async def test_start_uuid_duplicate(monkeypatch):
+async def test_start_uuid_repeat(monkeypatch):
+    visits = 1
+
     async def dummy_fetchrow(q, uuid):
-        return {"tg_id": 42}
+        return {"id": 1, "tg_id": 42}
+
+    async def dummy_execute(q, *args):
+        nonlocal visits
+        if "INSERT INTO visits" in q:
+            visits += 1
+
+    async def dummy_fetchval(q, *args):
+        return visits
 
     monkeypatch.setattr(reqqr.db, "fetchrow", dummy_fetchrow)
+    monkeypatch.setattr(reqqr.db, "execute", dummy_execute)
+    monkeypatch.setattr(reqqr.db, "fetchval", dummy_fetchval)
     msg = make_msg()
     await reqqr.start_uuid(msg, bot=msg.bot)
-    assert msg.answers == ["You are already registered."]
+    assert msg.answers == ["Это уже 2-е посещение"]
 
 
 @pytest.mark.asyncio
@@ -93,28 +112,34 @@ async def test_start_uuid_invalid(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_reg_success(monkeypatch):
-    called = {}
+    calls = {"guest": None, "visits": 0}
 
     async def dummy_fetchrow(q, uid):
         return {"user_id": uid}
 
-    async def dummy_fetchval(q):
-        return "uuid"
+    async def dummy_fetchval(q, *args):
+        if "gen_random_uuid" in q:
+            return "uuid"
+        return 1
 
     async def dummy_execute(q, *args):
-        called["exec"] = args
+        if "INSERT INTO visits" in q:
+            calls["visits"] += 1
+        else:
+            calls["guest"] = args
 
-    monkeypatch.setattr(admin.db, "fetchrow", dummy_fetchrow)
-    monkeypatch.setattr(admin.db, "fetchval", dummy_fetchval)
-    monkeypatch.setattr(admin.db, "execute", dummy_execute)
+    monkeypatch.setattr(reqqr.db, "fetchrow", dummy_fetchrow)
+    monkeypatch.setattr(reqqr.db, "fetchval", dummy_fetchval)
+    monkeypatch.setattr(reqqr.db, "execute", dummy_execute)
     msg = make_msg("/reg Name, +79998887766, 1990-01-01")
-    await admin.reg_guest(msg)
-    assert called["exec"] == (
+    await reqqr.reg_guest(msg)
+    assert calls["guest"] == (
         "uuid",
         "Name",
         "+79998887766",
         "1990-01-01",
     )
+    assert calls["visits"] == 1
     assert msg.answers == ["✅ Guest registered."]
 
 
@@ -123,9 +148,9 @@ async def test_reg_invalid_phone(monkeypatch):
     async def dummy_fetchrow(q, a):
         return {"user_id": a}
 
-    monkeypatch.setattr(admin.db, "fetchrow", dummy_fetchrow)
+    monkeypatch.setattr(reqqr.db, "fetchrow", dummy_fetchrow)
     msg = make_msg("/reg Name, 12345, 1990-01-01")
-    await admin.reg_guest(msg)
+    await reqqr.reg_guest(msg)
     assert msg.answers == ["Invalid phone"]
 
 
@@ -134,9 +159,9 @@ async def test_reg_invalid_date(monkeypatch):
     async def dummy_fetchrow(q, a):
         return {"user_id": a}
 
-    monkeypatch.setattr(admin.db, "fetchrow", dummy_fetchrow)
+    monkeypatch.setattr(reqqr.db, "fetchrow", dummy_fetchrow)
     msg = make_msg("/reg Name, +79998887766, 1990-13-01")
-    await admin.reg_guest(msg)
+    await reqqr.reg_guest(msg)
     assert msg.answers == ["Invalid date"]
 
 


### PR DESCRIPTION
## Summary
- record guest consent with new `agreed_at` column
- log guest visits in a new `visits` table
- update `/start` logic to set consent, track visits and reply on repeat
- add `/report` command for visit statistics
- log manual registration visits for consistency

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686b7c025264832eadbf5a701a5979f5