### PR TITLE
Fix admin QR import

### DIFF
--- a/modules/qr.py
+++ b/modules/qr.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import io
 import qrcode
 
+__all__ = ["make_qr_link"]
+
 
 def make_qr_link(uuid: str, bot_username: str) -> tuple[str, bytes]:
     url = f"t.me/{bot_username}?start={uuid}"

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -56,3 +56,9 @@ async def test_rm_admin_invalid(monkeypatch):
     await admin.rm_admin(msg)
     assert msg.answers == ["Invalid user ID"]
     assert not called
+
+
+def test_admin_loads():
+    import importlib
+    import modules.admin as admin_mod
+    importlib.reload(admin_mod)


### PR DESCRIPTION
## Summary
- export `make_qr_link` from `modules.qr`
- test that `modules.admin` loads

## Testing
- `pip install -r requirements.txt`
- `pip install pytest-asyncio`
- `pytest tests/test_admin.py::test_admin_loads -q`
- `pytest -q` *(fails: Could not connect to PostgreSQL)*

------
https://chatgpt.com/codex/tasks/task_e_6870b4c67154832ebee4cf17e98a4ad1