### PR TITLE
Fix admin QR import

### DIFF
--- a/modules/env.py
+++ b/modules/env.py
@@ -11,3 +11,6 @@ def get_env(name: str, default: str | None = None, *, required: bool = False) ->
         raise RuntimeError(f"{name} not set")
     return None
 
+
+OWNER_ID = int(get_env("OWNER_ID", required=True))
+

--- a/modules/qr.py
+++ b/modules/qr.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import io
 import qrcode
 
+__all__ = ["make_qr_link"]
+
 
 def make_qr_link(uuid: str, bot_username: str) -> tuple[str, bytes]:
     url = f"t.me/{bot_username}?start={uuid}"

--- a/modules/reqqr.py
+++ b/modules/reqqr.py
@@ -30,6 +30,9 @@ def _admin_only(func):
 
 @router.message(Command("start"))
 async def start_uuid(message: Message, bot: Bot) -> None:
+    owner_id = int(get_env("OWNER_ID", required=True))
+    if message.from_user.id == owner_id:
+        return
     parts = message.text.split() if message.text else []
     if len(parts) != 2:
         return

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -2,11 +2,11 @@ import os
 import sys
 import pathlib
 import pytest
-
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
-from modules import admin
+from datetime import datetime
 
 os.environ["OWNER_ID"] = "1"
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from modules import admin
 
 
 class DummyUser:
@@ -56,3 +56,18 @@ async def test_rm_admin_invalid(monkeypatch):
     await admin.rm_admin(msg)
     assert msg.answers == ["Invalid user ID"]
     assert not called
+
+
+def test_admin_loads():
+    import importlib
+    import modules.admin as admin_mod
+    importlib.reload(admin_mod)
+
+
+@pytest.mark.asyncio
+async def test_start_owner(monkeypatch):
+    monkeypatch.setattr(admin, "START_TIME", datetime.now())
+    monkeypatch.setattr(admin.pkgutil, "iter_modules", lambda *_: [])
+    msg = make_msg("/start")
+    await admin.start_cmd(msg)
+    assert msg.answers and msg.answers[0].startswith("Status: OK")

--- a/tests/test_menu.py
+++ b/tests/test_menu.py
@@ -3,10 +3,9 @@ import sys
 import pathlib
 import pytest
 
+os.environ["OWNER_ID"] = "1"
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 from modules import menu, admin
-
-os.environ["OWNER_ID"] = "1"
 
 class DummyUser:
     def __init__(self, uid):

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -3,10 +3,9 @@ import sys
 import pathlib
 import pytest
 
+os.environ["OWNER_ID"] = "1"
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 from modules import report
-
-os.environ["OWNER_ID"] = "1"
 
 
 class DummyUser:


### PR DESCRIPTION
## Summary
- export `make_qr_link` from `modules.qr`
- route /start based on OWNER_ID
- ensure /start works for owner and ignores owner in QR handler

## Testing
- `pip install -r requirements.txt`
- `pip install pytest-asyncio`
- `pytest tests/test_admin.py::test_start_owner -q`
- `pytest tests/test_reqqr.py::test_start_uuid_owner_skip -q`
- `pytest -q` *(fails: Could not connect to PostgreSQL)*

------
https://chatgpt.com/codex/tasks/task_e_6870b4c67154832ebee4cf17e98a4ad1